### PR TITLE
Adds package.json file so this can be installed through npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Pixel Union",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "jquery": "~2.1.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   "author": "Pixel Union",
   "license": "MIT",
   "dependencies": {
-    "jquery": "~2.1.0"
+    "jquery": "~1.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "Extended-Tumblr-Photoset",
+  "version": "1.8.0",
+  "repository": "https://github.com/PixelUnion/Extended-Tumblr-Photoset",
+  "description": "Responsive, customisable photosets for your Tumblr theme",
+  "main": "js/pxuPhotoset.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Pixel Union",
+  "license": "MIT"
+}


### PR DESCRIPTION
This allows for the plugin (and its dependency, jQuery) to be fetched like this:

```
npm install --save https://github.com/PixelUnion/Extended-Tumblr-Photoset
```

This is especially useful when multiple dependencies are required from `npm`, as they may all be installed with a single `npm i`.
