### PR TITLE
Tweaks to make this plugin easier to use with Browserify

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -93,11 +93,11 @@
 }
 
 .zoom {
-  background: url('http://static.tumblr.com/hugxd2w/kgem0so9j/zoom-icon.png');
+  background: url('//static.tumblr.com/hugxd2w/kgem0so9j/zoom-icon.png');
 }
 
 .info {
-  background: url('http://static.tumblr.com/hugxd2w/ffwm0so9t/info-icon.png');
+  background: url('//static.tumblr.com/hugxd2w/ffwm0so9t/info-icon.png');
   position: relative;
 }
 
@@ -138,7 +138,7 @@
 }
 
 .pxu-caption:before {
-  content: url('http://static.tumblr.com/hugxd2w/SSBm6wxmm/caption-icon.png');
+  content: url('//static.tumblr.com/hugxd2w/SSBm6wxmm/caption-icon.png');
   opacity: 0.5;
   filter: alpha(opacity = 50);
   -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";

--- a/js/pxuPhotoset.js
+++ b/js/pxuPhotoset.js
@@ -9,7 +9,16 @@
     + Licensed under the MIT license
 */
 
-(function( $ ){
+(function(factory) {
+    if (typeof define === 'function' && define.amd) {
+        define(['jquery'], factory);
+    } else if (typeof exports === 'object') {
+        module.exports = factory(require('jquery'));
+        require('../css/style.css');
+    } else {
+        factory(jQuery);
+    }
+})(function( $ ){
 
     $.fn.pxuPhotoset = function( options, callback ) {
 
@@ -390,5 +399,6 @@
         }); // end return each
 
     }; // end PXU Photoset Extended
+    return $;
 
-})( jQuery );
+});

--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Pixel Union",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "jquery": "~2.1.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,12 @@
   "author": "Pixel Union",
   "license": "MIT",
   "dependencies": {
-    "jquery": "~1.11.0"
+    "jquery": "~1.11.0",
+    "cssify": "~0.4.1"
+  },
+  "browserify": {
+    "transform": [
+      "cssify"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   "author": "Pixel Union",
   "license": "MIT",
   "dependencies": {
-    "jquery": "~2.1.0"
+    "jquery": "~1.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "Extended-Tumblr-Photoset",
+  "version": "1.8.0",
+  "repository": "https://github.com/PixelUnion/Extended-Tumblr-Photoset",
+  "description": "Responsive, customisable photosets for your Tumblr theme",
+  "main": "js/pxuPhotoset.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Pixel Union",
+  "license": "MIT"
+}


### PR DESCRIPTION
With these tweaks in place, you can load up PXU photosets just by running something like this, no need for separate CSS or JS files:

``` js
var $ = require('Extended-Tumblr-Photoset');
$('.photo-slideshow').pxuPhotoset();
```

There's also a crack at AMD support (I added a UMD-specified definition, which does AMD too), but that one doesn't do CSS because I'm not familiar enough with AMD to know how it handles CSS.

This is all fully backwards-compatible with using the script the "traditional" way, in a <script> tag.

(Note that this request's dependent on the earlier package.json pull request. Not sure what the right way to handle situations like this is?)
